### PR TITLE
Fix context

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function maybe (fn){
 
         if(!valid) return void 0;
         
-        result = fn.apply(null, args);
+        result = fn.apply(this, args);
         
         return typeof result === 'function' ? maybe(result) : result;
     }

--- a/index.js
+++ b/index.js
@@ -3,14 +3,14 @@ var slice = Array.prototype.slice;
 module.exports = function maybe (fn){
     return function(){
         var args = slice.call(arguments),
-            valid,
+            invalid,
             result;
         
-        valid = args.reduce(function(curr, prev){
-            return curr && prev != null;
-        }, true);
+        invalid = args.some(function(arg){
+            return arg == null;
+        });
 
-        if(!valid) return void 0;
+        if(invalid) return void 0;
         
         result = fn.apply(this, args);
         

--- a/test/index.js
+++ b/test/index.js
@@ -11,6 +11,14 @@ var test = require('tap').test,
     },
     mayCurriedAdd = maybe(curriedAdd);
 
+function DummyClass(){}
+DummyClass.prototype.setValue = maybe(function(value){
+    this._value = value;
+});
+DummyClass.prototype.getValue = function(){
+    return this._value;
+};
+
 test('returns undefined when one or more args are null', function(t){
     var result = mayAdd(null,1);
     t.plan(1);
@@ -38,4 +46,18 @@ test('works correctly with curried functions', function(t){
     t.equals(mayCurriedAdd(null,1), void 0);
     t.equals(mayCurriedAdd(1)(null), void 0);
     t.equals(mayCurriedAdd(1)(2), 3);
+});
+
+test('binds context correctly for instance methods', function(t){
+    var dummy = new DummyClass();
+    t.plan(3);
+
+    dummy.setValue(42);
+    t.equals(dummy.getValue(), 42);
+
+    dummy.setValue(void 0);
+    t.equals(dummy.getValue(), 42);
+
+    dummy.setValue(null);
+    t.equals(dummy.getValue(), 42);
 });

--- a/test/index.js
+++ b/test/index.js
@@ -3,11 +3,39 @@ var test = require('tap').test,
     add = function(a,b){
         return a + b
     },
-    mayAdd = maybe(add);
+    mayAdd = maybe(add),
+    curriedAdd = function(a){
+        return function(b){
+            return a + b;
+        };
+    },
+    mayCurriedAdd = maybe(curriedAdd);
 
-test('returns undefined when invalid args are passed', function(t){
+test('returns undefined when one or more args are null', function(t){
     var result = mayAdd(null,1);
     t.plan(1);
 
-    t.equals(void 0, result);
+    t.equals(result, void 0);
+});
+
+test('returns undefined when one or more args are undefined', function(t){
+    var result = mayAdd(void 0,1);
+    t.plan(1);
+
+    t.equals(result, void 0);
+});
+
+test('returns function result when no args are null/undefined', function(t){
+    var result = mayAdd(2,1);
+    t.plan(1);
+
+    t.equals(result, add(2,1));
+});
+
+test('works correctly with curried functions', function(t){
+    t.plan(3);
+
+    t.equals(mayCurriedAdd(null,1), void 0);
+    t.equals(mayCurriedAdd(1)(null), void 0);
+    t.equals(mayCurriedAdd(1)(2), 3);
 });


### PR DESCRIPTION
Primarily this PR preserves `this` so that `maybe` can be used when defining methods on a class. I've also added full test coverage and made a minor tweak to the argument validation to allow it to return early as soon as the first invalid argument is found.

Closes #1.
